### PR TITLE
FIX: Update data validation and make tests a package to fix imports

### DIFF
--- a/findoutlie/tests/test_detectors.py
+++ b/findoutlie/tests/test_detectors.py
@@ -24,7 +24,7 @@ import numpy as np
 
 # This import needs the directory containing the findoutlie directory
 # on the Python path.
-from detectors import iqr_detector
+from ..detectors import iqr_detector
 
 
 def test_iqr_detector():

--- a/findoutlie/tests/test_spm_funcs.py
+++ b/findoutlie/tests/test_spm_funcs.py
@@ -27,7 +27,7 @@ import nibabel as nib
 
 # This import needs the directory containing the findoutlie directory
 # on the Python path.
-from spm_funcs import get_spm_globals, spm_global
+from ..spm_funcs import get_spm_globals, spm_global
 
 
 def test_spm_globals():

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -53,15 +53,15 @@ def validate_data(data_directory):
         ``hash_list.txt`` file.
     """
     # Read lines from ``hash_list.txt`` file.
-    for line in open(os.path.join(data_directory, 'data_hashes.txt'), 'rt'):
-    # Split into SHA1 hash and filename
-    hash, filename = line.strip().split()
-    # Calculate actual hash for given filename.
-    actual_hash = file_hash(os.path.join(data_directory, filename))
-    # If hash for filename is not the same as the one in the file, raise
-    # ValueError
-    if hash != actual_hash:
-        raise ValueError("Hash for {} does not match".format(filename))
+    for line in open(os.path.join(data_directory, 'group-01/hash_list.txt'), 'rt'):
+        # Split into SHA1 hash and filename
+        hash, filename = line.strip().split()
+        # Calculate actual hash for given filename.
+        actual_hash = file_hash(os.path.join(data_directory, filename))
+        # If hash for filename is not the same as the one in the file, raise
+        # ValueError
+        if hash != actual_hash:
+            raise ValueError("Hash for {} does not match".format(filename))
 
 
 def main():


### PR DESCRIPTION
Found while reviewing for #10. I was able to make validation work with an indentation increase in the body of a for loop and modifying the name of the hash file.

The fix in the `tests/` directory adds `__init__.py` to cause Python to treat it as a package and allow relative imports. Alternatively, you could have used something like:

```Python
from findoutlie.detectors import iqr_detector
```

This would find `findoutlie` in the Python path and load the `detectors` submodule without making `findoutlie.tests` a package. I personally prefer to make `*.tests` importable packages that are a full part of the package.

Note that this does not fix the CI tests, but it does make them fail less immediately...